### PR TITLE
Improving Single-Master Deployment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Kubernetes Cluster with Multipass
 
+This repository contains a simple script to set up a simple Kubernetes cluster via Kubeadm for learning purposes. It deploys the latest version (v1.29) using Cilium as CNI without Kubeproxy. It will create Ubuntu 22.04 LTS VMs on your machine using Multipass.
+
 ## Requirements
 
 Make sure you have [Multipass](https://multipass.run/) installed on your machine.
@@ -33,10 +35,10 @@ From there, `kubectl` is already configured for the default user (i.e., `ubuntu`
 
 ```bash=
 ubuntu@k8smaster:~$ k get nodes -o wide
-NAME         STATUS   ROLES                  AGE   VERSION   INTERNAL-IP     EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION       CONTAINER-RUNTIME
-k8smaster    Ready    control-plane,master   56m   v1.20.4   192.168.75.6    <none>        Ubuntu 18.04.5 LTS   4.15.0-136-generic   containerd://1.3.3
-k8sworker1   Ready    <none>                 11m   v1.20.4   192.168.75.11   <none>        Ubuntu 18.04.5 LTS   4.15.0-136-generic   containerd://1.3.3
-k8sworker2   Ready    <none>                 10m   v1.20.4   192.168.75.12   <none>        Ubuntu 18.04.5 LTS   4.15.0-136-generic   containerd://1.3.3
+NAME         STATUS   ROLES           AGE     VERSION   INTERNAL-IP     EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION      CONTAINER-RUNTIME
+k8smaster    Ready    control-plane   4m31s   v1.29.0   192.168.65.39   <none>        Ubuntu 22.04.3 LTS   5.15.0-91-generic   containerd://1.7.2
+k8sworker1   Ready    <none>          2m23s   v1.29.0   192.168.65.40   <none>        Ubuntu 22.04.3 LTS   5.15.0-91-generic   containerd://1.7.2
+k8sworker2   Ready    <none>          34s     v1.29.0   192.168.65.41   <none>        Ubuntu 22.04.3 LTS   5.15.0-91-generic   containerd://1.7.2
 ```
 
 ## Clean up

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -4,11 +4,7 @@ set -euo pipefail
 trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 type multipass >/dev/null 2>&1 || { echo >&2 "multipass required but it's not installed; aborting."; exit 1; }
 
-instances=$(multipass list | grep "^k8s" | awk '{print $1}')
-
-for instance in $instances; do
-  echo "Removing $instance ..."
-  multipass delete $instance
-done
+instances=$(multipass list | grep "^k8s" | awk '{print $1}' | tr '\n' ' ')
+multipass delete --purge $instances
 
 echo "Done!"

--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -3,35 +3,50 @@ package_upgrade: true
 
 write_files:
 
-- owner: root:root
-  path: /etc/modules-load.d/containerd.conf
-  permissions: '0644'
+- path: /etc/systemd/resolved.conf
+  append: true
+  content: |
+    MulticastDNS=yes
+
+- path: /etc/systemd/system/mdns@.service
+  content: |
+    [Service]
+    Type=oneshot
+    ExecStart=/usr/bin/resolvectl mdns %i yes
+    After=sys-subsystem-net-devices-%i.device
+    [Install]
+    WantedBy=sys-subsystem-net-devices-%i.device
+
+- path: /etc/modules-load.d/containerd.conf
   content: |
     overlay
     br_netfilter
 
-- owner: root:root
-  path: /etc/sysctl.d/k8s.conf
-  permissions: '0644'
+- path: /etc/sysctl.d/no-ipv6.conf
+  content: |
+    net.ipv6.conf.all.disable_ipv6     = 1
+    net.ipv6.conf.default.disable_ipv6 = 1
+
+- path: /etc/sysctl.d/k8s.conf
   content: |
     net.bridge.bridge-nf-call-iptables  = 1
     net.bridge.bridge-nf-call-ip6tables = 1
     net.ipv4.ip_forward                 = 1
 
 # https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#dpkg-k8s-package-repo
-- owner: root:root
-  path: /usr/local/bin/kubernetes-install.sh
+- path: /usr/local/bin/kubernetes-install.sh
   permissions: '0755'
   content: |
     #!/bin/bash
-    curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-    echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /' | tee /etc/apt/sources.list.d/kubernetes.list
+    DEBIAN_FRONTEND=noninteractive
+    VERSION=v1.29
+    curl -fsSL https://pkgs.k8s.io/core:/stable:/${VERSION}/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+    echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/${VERSION}/deb/ /" | tee /etc/apt/sources.list.d/kubernetes.list
     apt-get update
     apt-get install -y kubelet kubeadm kubectl
     apt-mark hold kubelet kubeadm kubectl
 
-- owner: root:root
-  path: /usr/local/bin/kubernetes-setup-kubectl.sh
+- path: /usr/local/bin/kubernetes-setup-kubectl.sh
   permissions: '0755'
   content: |
     #!/bin/bash
@@ -47,22 +62,24 @@ write_files:
     complete -F __start_kubectl k
     EOF
 
-- owner: root:root
-  path: /usr/local/bin/kubernetes-setup-cni.sh
+# https://docs.cilium.io/en/stable/installation/k8s-install-kubeadm/
+- path: /usr/local/bin/kubernetes-setup-cni.sh
   permissions: '0755'
   content: |
     #!/bin/bash
+    snap install helm --classic
+    helm repo add cilium https://helm.cilium.io/
+    helm repo update
     export KUBECONFIG=/etc/kubernetes/admin.conf
-    kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/v3.26.1/manifests/tigera-operator.yaml
-    curl https://raw.githubusercontent.com/projectcalico/calico/v3.26.1/manifests/custom-resources.yaml | sed '/cidr/s/192.168.0.0/10.244.0.0/' | kubectl apply -f -
+    ipaddr=$(ifconfig | grep 'inet[^6]' | awk '{print $2}' | grep -v '127.0.0.1')
+    helm install cilium cilium/cilium -n kube-system --set kubeProxyReplacement=true --set k8sServiceHost=${ipaddr} --set k8sServicePort=6443 --wait
 
-- owner: root:root
-  path: /usr/local/bin/kubernetes-setup-master.sh # Should only runs on the master node
+- path: /usr/local/bin/kubernetes-setup-master.sh
   permissions: '0755'
   content: |
     #!/bin/bash
     ipaddr=$(ifconfig | grep 'inet[^6]' | awk '{print $2}' | grep -v '127.0.0.1')
-    kubeadm init --apiserver-advertise-address=$ipaddr --pod-network-cidr=10.244.0.0/16
+    kubeadm init --apiserver-advertise-address=${ipaddr} --pod-network-cidr=10.244.0.0/16 --skip-phases=addon/kube-proxy
     kubeadm token create --print-join-command > /tmp/setup_worker.sh
     /usr/local/bin/kubernetes-setup-cni.sh
     /usr/local/bin/kubernetes-setup-kubectl.sh
@@ -77,13 +94,16 @@ packages:
 - containerd
 
 runcmd:
+- systemctl restart systemd-sysctl
+- systemctl restart systemd-resolved.service
+- systemctl start mdns@ens3.service
+- systemctl enable mdns@ens3.service
 - timedatectl set-timezone America/New_York
 - timedatectl set-ntp on
 - systemctl stop apparmor
 - systemctl disable apparmor
 - modprobe overlay
 - modprobe br_netfilter
-- sysctl --system
 - swapoff -a
 - sed -i '/ swap / s/^\(.*\)$/#\1/g' /etc/fstab
 - mkdir -p /etc/containerd

--- a/start.sh
+++ b/start.sh
@@ -35,7 +35,7 @@ echo "Creating cluster using: workers=${workers}, cpus=${cpus}, memory=${memory}
 cmd="setup_worker.sh"
 
 # Start and configure Master (do not change vm name)
-echo "Starting Master..."
+echo "Creating Master..."
 multipass launch -c ${cpus} -m ${memory}g -n k8smaster --cloud-init kubernetes.yaml
 multipass exec k8smaster -- sudo kubernetes-setup-master.sh
 multipass transfer k8smaster:/tmp/${cmd} .
@@ -43,7 +43,7 @@ multipass transfer k8smaster:/tmp/${cmd} .
 # Start and configure Workers (do not change vm name)
 for i in $(seq 1 ${workers}); do
   worker="k8sworker${i}"
-  echo "Starting Worker ${worker}..."
+  echo "Creating Worker ${worker}..."
   multipass launch -c ${cpus} -m ${memory}g -d ${disk}g -n ${worker} --cloud-init kubernetes.yaml
   multipass transfer ./${cmd} ${worker}:/tmp/
   multipass exec ${worker} -- sudo bash /tmp/${cmd}


### PR DESCRIPTION
* Upgrade Kubernetes to 1.29.
* Use Cilium as the default CNI, replacing Kubeproxy.
* Enable mDNS on all VMs (all reachable via the `.local` Domain, including from the macOS Host).
* Simplify and improve the cloud-init script.
* Simplify and improve the deployment scripts.