### PR TITLE
Improving Multi-Master Deployment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Make sure you have [Multipass](https://multipass.run/) installed on your machine
 
 ## Start the cluster
 
-The following starts a cluster with a single master and 3 workers on Ubuntu with 2 CPUs and 8GB of RAM per instance, execute the following command:
+The following starts a cluster with a single master and 3 workers with 2 CPUs and 16GB of RAM per instance:
 
 ```bash=
-./start.sh --workers 3 --cpus 2 --memory 16g
+./start.sh --workers 3 --cpus 2 --memory 16
 ```
 
 Default values are:
@@ -19,7 +19,8 @@ Default values are:
 * 2 worker nodes (`--workers`)
 * 2 CPUs per VM (`--cpus`)
 * 8 GB of RAM per VM (`--memory`)
-* The master node will use the same settings
+* 50 GB for Disk per worker VM (`--disk`)
+* All node kinds share the same CPU, Memory, and Disk settings
 
 The cluster is initialized using [cloud-init](https://cloudinit.readthedocs.io/en/latest/), and all the detailes live inside the [kubernetes.yaml](./kubernetes.yaml) file.
 
@@ -32,14 +33,6 @@ multipass shell k8smaster
 ```
 
 From there, `kubectl` is already configured for the default user (i.e., `ubuntu`), and the alias `k` can be used. In both cases, bash-completion is enabled.
-
-```bash=
-ubuntu@k8smaster:~$ k get nodes -o wide
-NAME         STATUS   ROLES           AGE     VERSION   INTERNAL-IP     EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION      CONTAINER-RUNTIME
-k8smaster    Ready    control-plane   4m31s   v1.29.0   192.168.65.39   <none>        Ubuntu 22.04.3 LTS   5.15.0-91-generic   containerd://1.7.2
-k8sworker1   Ready    <none>          2m23s   v1.29.0   192.168.65.40   <none>        Ubuntu 22.04.3 LTS   5.15.0-91-generic   containerd://1.7.2
-k8sworker2   Ready    <none>          34s     v1.29.0   192.168.65.41   <none>        Ubuntu 22.04.3 LTS   5.15.0-91-generic   containerd://1.7.2
-```
 
 ## Clean up
 

--- a/multimaster/README.md
+++ b/multimaster/README.md
@@ -1,15 +1,19 @@
 # Kubernetes Cluster with Multipass
 
+This repository contains a simple script to set up a simple Kubernetes cluster via Kubeadm for learning purposes. It deploys the latest version (v1.29) using Cilium as CNI without Kubeproxy. It will create Ubuntu 22.04 LTS VMs on your machine using Multipass.
+
+This allows you to deploy either a single master or a multi-master deployment.
+
 ## Requirements
 
 Make sure you have [Multipass](https://multipass.run/) installed on your machine.
 
 ## Start the cluster
 
-The following starts a cluster with a single master and 3 workers on Ubuntu with 2 CPUs and 8GB of RAM per instance, execute the following command:
+The following starts a cluster with 3 masters behind a proxy and 3 workers with 2 CPUs and 16GB of RAM per instance:
 
 ```bash=
-./start.sh --workers 3 --cpus 2 --memory 16g
+./start.sh --workers 3 --cpus 2 --memory 16
 ```
 
 Default values are:
@@ -18,8 +22,8 @@ Default values are:
 * 2 worker nodes (`--workers`)
 * 2 CPUs per VM (`--cpus`)
 * 8 GB of RAM per VM (`--memory`)
-* 20 GB for Disk per Worker VM (`--disk`)
-* The master node will use the same settings
+* 50 GB for Disk per worker VM (`--disk`)
+* All node kinds share the same CPU and Memory.
 
 The cluster is initialized using [cloud-init](https://cloudinit.readthedocs.io/en/latest/), and all the detailes live inside the [kubernetes.yaml](./kubernetes.yaml) file.
 
@@ -36,11 +40,11 @@ From there, `kubectl` is already configured for the default user (i.e., `ubuntu`
 However, if you choose to have multiple master servers, an additional load balancer was configured, and you can do the following from hour machine (assuming you have `kubectl` installed):
 
 ```bash=
-KUBECONFIG=$(pwd)/kube-config.yaml
+export KUBECONFIG=$(pwd)/kube_config.conf
 kubectl get nodes
 ```
 
-`kube_config.conf` was created by the `start.sh` script and should use the LB to access the cluster.
+> The `kube_config.conf` file was created by the `start.sh` script and should use the LB to access the cluster.
 
 ## Clean up
 

--- a/multimaster/cleanup.sh
+++ b/multimaster/cleanup.sh
@@ -4,13 +4,7 @@ set -euo pipefail
 trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 type multipass >/dev/null 2>&1 || { echo >&2 "multipass required but it's not installed; aborting."; exit 1; }
 
-instances=$(multipass list | grep "^k8s" | awk '{print $1}')
-
-for instance in $instances; do
-  echo "Removing $instance ..."
-  multipass delete $instance
-done
-
-multipass purge
+instances=$(multipass list | grep "^k8s" | awk '{print $1}' | tr '\n' ' ')
+multipass delete --purge $instances
 
 echo "Done!"

--- a/multimaster/kubernetes.yaml
+++ b/multimaster/kubernetes.yaml
@@ -1,41 +1,57 @@
 #cloud-config
 package_upgrade: true
-manage_etc_hosts: false
 
 write_files:
 
-- owner: root:root
-  path: /etc/modules-load.d/containerd.conf
-  permissions: '0644'
+- path: /etc/systemd/resolved.conf
+  append: true
+  content: |
+    MulticastDNS=yes
+
+- path: /etc/systemd/system/mdns@.service
+  content: |
+    [Service]
+    Type=oneshot
+    ExecStart=/usr/bin/resolvectl mdns %i yes
+    After=sys-subsystem-net-devices-%i.device
+    [Install]
+    WantedBy=sys-subsystem-net-devices-%i.device
+
+- path: /etc/modules-load.d/containerd.conf
   content: |
     overlay
     br_netfilter
 
-- owner: root:root
-  path: /etc/sysctl.d/k8s.conf
-  permissions: '0644'
+- path: /etc/sysctl.d/no-ipv6.conf
+  content: |
+    net.ipv6.conf.all.disable_ipv6     = 1
+    net.ipv6.conf.default.disable_ipv6 = 1
+
+- path: /etc/sysctl.d/k8s.conf
   content: |
     net.bridge.bridge-nf-call-iptables  = 1
     net.bridge.bridge-nf-call-ip6tables = 1
     net.ipv4.ip_forward                 = 1
 
 # https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#dpkg-k8s-package-repo
-- owner: root:root
-  path: /usr/local/bin/kubernetes-install.sh
+- path: /usr/local/bin/kubernetes-install.sh
   permissions: '0755'
   content: |
     #!/bin/bash
-    curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-    echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /' | tee /etc/apt/sources.list.d/kubernetes.list
+    set -e
+    DEBIAN_FRONTEND=noninteractive
+    VERSION=v1.29
+    curl -fsSL https://pkgs.k8s.io/core:/stable:/${VERSION}/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+    echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/${VERSION}/deb/ /" | tee /etc/apt/sources.list.d/kubernetes.list
     apt-get update
     apt-get install -y kubelet kubeadm kubectl
     apt-mark hold kubelet kubeadm kubectl
 
-- owner: root:root
-  path: /usr/local/bin/kubernetes-setup-kubectl.sh
+- path: /usr/local/bin/kubernetes-setup-kubectl.sh
   permissions: '0755'
   content: |
     #!/bin/bash
+    set -e
     kubectl completion bash > /etc/bash_completion.d/kubectl
     user=ubuntu
     home=/home/$user
@@ -48,51 +64,55 @@ write_files:
     complete -F __start_kubectl k
     EOF
 
-- owner: root:root
-  path: /usr/local/bin/kubernetes-setup-cni.sh
+# https://docs.cilium.io/en/stable/installation/k8s-install-kubeadm/
+- path: /usr/local/bin/kubernetes-setup-cni.sh
   permissions: '0755'
   content: |
     #!/bin/bash
+    set -e
+    snap install helm --classic
+    helm repo add cilium https://helm.cilium.io/
+    helm repo update
     export KUBECONFIG=/etc/kubernetes/admin.conf
-    kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/v3.26.1/manifests/tigera-operator.yaml
-    curl https://raw.githubusercontent.com/projectcalico/calico/v3.26.1/manifests/custom-resources.yaml | sed '/cidr/s/192.168.0.0/10.244.0.0/' | kubectl apply -f -
+    ipaddr=$(ifconfig | grep 'inet[^6]' | awk '{print $2}' | grep -v '127.0.0.1')
+    helm install cilium cilium/cilium -n kube-system --set kubeProxyReplacement=true --set k8sServiceHost=${ipaddr} --set k8sServicePort=6443 --wait
 
-- owner: root:root
-  path: /usr/local/bin/kubernetes-setup-single-master.sh
+- path: /usr/local/bin/kubernetes-setup-single-master.sh
   permissions: '0755'
   content: |
     #!/bin/bash
+    set -e
     ipaddr=$(ifconfig | grep 'inet[^6]' | awk '{print $2}' | grep -v '127.0.0.1')
-    kubeadm init --apiserver-advertise-address=$ipaddr --pod-network-cidr=10.244.0.0/16
+    kubeadm init --apiserver-advertise-address=${ipaddr} --pod-network-cidr=10.244.0.0/16 --skip-phases=addon/kube-proxy
     kubeadm token create --print-join-command > /tmp/setup_worker.sh
     /usr/local/bin/kubernetes-setup-cni.sh
     /usr/local/bin/kubernetes-setup-kubectl.sh
 
-- owner: root:root
-  path: /usr/local/bin/kubernetes-setup-primary-master.sh
+- path: /usr/local/bin/kubernetes-setup-primary-master.sh
   permissions: '0755'
   content: |
     #!/bin/bash
-    proxy_fqdn=${1-k8smain}
+    set -e
+    proxy_fqdn=${1-k8smain.local}
     ipaddr=$(ifconfig | grep 'inet[^6]' | awk '{print $2}' | grep -v '127.0.0.1')
-    kubeadm init --apiserver-advertise-address=$ipaddr --pod-network-cidr=10.244.0.0/16 --control-plane-endpoint "$proxy_fqdn:6443" --upload-certs
+    kubeadm init --apiserver-advertise-address=${ipaddr} --pod-network-cidr=10.244.0.0/16 --skip-phases=addon/kube-proxy --control-plane-endpoint=${proxy_fqdn}:6443 --upload-certs
     cert_key=$(sudo kubeadm init phase upload-certs --upload-certs | tail -n 1)
     kubeadm token create --print-join-command --certificate-key $cert_key > /tmp/setup_secondary_master.sh
     kubeadm token create --print-join-command > /tmp/setup_worker.sh
     /usr/local/bin/kubernetes-setup-cni.sh
     /usr/local/bin/kubernetes-setup-kubectl.sh
 
-- owner: root:root
-  path: /usr/local/bin/kubernetes-setup-secondary-master.sh
+- path: /usr/local/bin/kubernetes-setup-secondary-master.sh
   permissions: '0755'
   content: |
     #!/bin/bash
+    set -e
     if ! [ -f "/tmp/setup_secondary_master.sh" ]; then
       echo "Cannot find join script..."
       exit
     fi
     ipaddr=$(ifconfig | grep 'inet[^6]' | awk '{print $2}' | grep -v '127.0.0.1')
-    $(cat /tmp/setup_secondary_master.sh) --apiserver-advertise-address=$ipaddr
+    $(cat /tmp/setup_secondary_master.sh) --apiserver-advertise-address=${ipaddr}
 
 packages:
 - net-tools
@@ -104,13 +124,16 @@ packages:
 - containerd
 
 runcmd:
+- systemctl restart systemd-sysctl
+- systemctl restart systemd-resolved.service
+- systemctl start mdns@ens3.service
+- systemctl enable mdns@ens3.service
 - timedatectl set-timezone America/New_York
 - timedatectl set-ntp on
 - systemctl stop apparmor
 - systemctl disable apparmor
 - modprobe overlay
 - modprobe br_netfilter
-- sysctl --system
 - swapoff -a
 - sed -i '/ swap / s/^\(.*\)$/#\1/g' /etc/fstab
 - mkdir -p /etc/containerd

--- a/multimaster/load-balancer.yaml
+++ b/multimaster/load-balancer.yaml
@@ -1,37 +1,57 @@
 #cloud-config
 package_upgrade: true
-manage_etc_hosts: false
 
 write_files:
+
+- path: /etc/systemd/resolved.conf
+  append: true
+  content: |
+    MulticastDNS=yes
+
+- path: /etc/systemd/system/mdns@.service
+  content: |
+    [Service]
+    Type=oneshot
+    ExecStart=/usr/bin/resolvectl mdns %i yes
+    After=sys-subsystem-net-devices-%i.device
+    [Install]
+    WantedBy=sys-subsystem-net-devices-%i.device
+
+- path: /etc/sysctl.d/no-ipv6.conf
+  content: |
+    net.ipv6.conf.all.disable_ipv6     = 1
+    net.ipv6.conf.default.disable_ipv6 = 1
+
 - owner: root:root
   path: /etc/haproxy/setup.sh
   permissions: '0755'
   content: |
     #!/bin/bash
+    set -e
     if [ -f "/etc/haproxy.configured" ]; then
       echo "Already configured."
       exit
     fi
     masters=${1-3}
     master_prefix=${2-k8smaster}
-    proxy_ip=$(ifconfig | grep 'inet[^6]' | awk '{print $2}' | grep -v '127.0.0.1')
     cp /etc/haproxy/haproxy.cfg /etc/haproxy/haproxy.cfg.bak
     cat <<EOF | sudo tee -a /etc/haproxy/haproxy.cfg
-    frontend kubernetes-frontend
-        bind $proxy_ip:6443
+    frontend kube-apiserver
+        bind :6443
         mode tcp
         option tcplog
-        default_backend kubernetes-backend
-    backend kubernetes-backend
+        default_backend kube-apiserver
+    backend kube-apiserver
         mode tcp
         option tcp-check
         balance roundrobin
+        default-server inter 10s downinter 5s rise 2 fall 2 slowstart 60s maxconn 250 maxqueue 256 weight 100
     EOF
     for i in $(seq 1 ${masters}); do
       master="${master_prefix}${i}"
-      ip=$(grep ${master} /etc/hosts | awk '{print $1}')
+      ip=$(dig ${master}.local +short)
       cat <<EOF | sudo tee -a /etc/haproxy/haproxy.cfg
-        server ${master} ${ip}:6443 check fall 3 rise 2
+        server ${master} ${ip}:6443 check
     EOF
     done
     touch /etc/haproxy.configured
@@ -42,6 +62,10 @@ packages:
 - haproxy
 
 runcmd:
+- systemctl restart systemd-sysctl
+- systemctl restart systemd-resolved.service
+- systemctl start mdns@ens3.service
+- systemctl enable mdns@ens3.service
 - timedatectl set-timezone America/New_York
 - timedatectl set-ntp on
 - systemctl stop apparmor

--- a/multimaster/start.sh
+++ b/multimaster/start.sh
@@ -9,7 +9,7 @@ masters="3"
 workers="2"
 cpus="2"
 memory="8"
-disk="20"
+disk="50"
 
 if [[ $# -gt 0 ]] && [[ "$1" == "-h" ]]; then
   cat <<EOF
@@ -48,7 +48,6 @@ fi
 proxy_hostname="k8smain"
 master_prefix="k8smaster"
 worker_prefix="k8sworker"
-hosts_file="/tmp/__etc_hosts"
 
 # Infrastructure Verification
 nodes=$(($masters + $workers))
@@ -65,75 +64,52 @@ if [[ ${masters} > 1 ]]; then
   echo "An additional VM with 1 CPU and 1GB of RAM will be started as the Load Balancer."
 fi
 
-read -p "Do you want to proceed? " -n 1 -r
+read -p "Do you want to proceed? [y/n]" -n 1 -r
 echo
 if [[ ! $REPLY =~ ^[Yy]$ ]]; then
   exit
 fi
 echo "Creating Kubernetes cluster..."
 
-# Start Load Balancer if applies (do not change vm name)
-if [[ ${masters} > 1 ]]; then
-  echo "Starting Load Balancer ${proxy_hostname}..."
-  multipass launch -c 1 -m 1g -n ${proxy_hostname} --cloud-init load-balancer.yaml
-fi
-
-# Start Masters (do not change vm name)
+# Start VMs for the Master nodes
 for i in $(seq 1 ${masters}); do
   master="${master_prefix}${i}"
   echo "Starting Master ${master}..."
   multipass launch -c ${cpus} -m ${memory}g -n ${master} --cloud-init kubernetes.yaml
 done
 
-# Start Workers (do not change vm name)
+# Start VMs for the Worker nodes
 for i in $(seq 1 ${workers}); do
   worker="${worker_prefix}${i}"
   echo "Starting Worker ${worker}..."
   multipass launch -c ${cpus} -m ${memory}g -d ${disk}g -n ${worker} --cloud-init kubernetes.yaml
 done
 
-# Update the /etc/hosts file on each VM (and configure proxy)
-multipass list --format json | jq -jr '.list[]|select(.name|test("k8s"))|.ipv4[0]," ",.name,"\n"' > ${hosts_file}
+# Configure Control Plane nodes
 if [[ ${masters} > 1 ]]; then
-  echo "Updating /etc/hosts for ${proxy_hostname}..."
-  multipass transfer ${hosts_file} ${proxy_hostname}:${hosts_file}
-  multipass exec ${proxy_hostname} -- sh -c "cat ${hosts_file} | sudo tee -a /etc/hosts"
+  echo "Configuring Load Balancer..."
+  multipass launch -c 1 -m 1g -n ${proxy_hostname} --cloud-init load-balancer.yaml
   multipass exec ${proxy_hostname} -- sudo /etc/haproxy/setup.sh ${masters} ${master_prefix}
-fi
-for i in $(seq 1 ${masters}); do
-  master="${master_prefix}${i}"
-  echo "Updating /etc/hosts for ${master}..."
-  multipass transfer ${hosts_file} ${master}:${hosts_file}
-  multipass exec ${master} -- sh -c "cat ${hosts_file} | sudo tee -a /etc/hosts"
-done
-for i in $(seq 1 ${workers}); do
-  worker="${worker_prefix}${i}"
-  echo "Updating /etc/hosts for ${worker}..."
-  multipass transfer ${hosts_file} ${worker}:${hosts_file}
-  multipass exec ${worker} -- sh -c "cat ${hosts_file} | sudo tee -a /etc/hosts"
-done
-
-# Configure/Start Cluster
-master="${master_prefix}1"
-if [[ ${masters} > 1 ]]; then
+  master="${master_prefix}1"
   echo "Initializing primary master node ${master}..."
-  proxy_ip=$(grep ${proxy_hostname} /tmp/__etc_hosts | awk '{print $1}')
-  multipass exec ${master} -- sudo kubernetes-setup-primary-master.sh ${proxy_ip}
+  multipass exec ${master} -- sudo kubernetes-setup-primary-master.sh ${proxy_hostname}.local
   multipass transfer ${master}:/tmp/setup_secondary_master.sh .
   multipass transfer ${master}:/tmp/setup_worker.sh .
+  for i in $(seq 2 ${masters}); do
+    master="${master_prefix}${i}"
+    echo "Initializing secondary master node ${master}..."
+    multipass transfer ./setup_secondary_master.sh ${master}:/tmp/
+    multipass exec ${master} -- sudo bash kubernetes-setup-secondary-master.sh
+  done
 else
   master="${master_prefix}1"
   echo "Initializing single master node ${master}..."
   multipass exec ${master} -- sudo kubernetes-setup-single-master.sh
   multipass transfer ${master}:/tmp/setup_worker.sh .
 fi
-multipass transfer ${master}:/home/ubuntu/.kube/config kube_config.conf
-for i in $(seq 2 ${masters}); do
-  master="${master_prefix}${i}"
-  echo "Initializing secondary master node ${master}..."
-  multipass transfer ./setup_secondary_master.sh ${master}:/tmp/
-  multipass exec ${master} -- sudo bash kubernetes-setup-secondary-master.sh
-done
+multipass transfer ${master_prefix}1:/home/ubuntu/.kube/config kube_config.conf
+
+# Configure Worker nodes
 for i in $(seq 1 ${workers}); do
   worker="${worker_prefix}${i}"
   echo "Initializing worker node ${worker}..."
@@ -142,6 +118,7 @@ for i in $(seq 1 ${workers}); do
 done
 
 # Finalizing
-rm -f ./setup_secondary_master.sh ./setup_worker.sh ${hosts_file}
-echo "Make sure to copy the kube_config.conf file to ~/.kube/config"
-echo "Done!"
+rm -f ./setup_secondary_master.sh ./setup_worker.sh
+echo 'To access the cluster locally use:'
+echo 'export KUBECONFIG=$(pwd)/kube_config.conf'
+echo 'Done!'


### PR DESCRIPTION
* Upgrade Kubernetes to 1.29.
* Use Cilium as the default CNI, replacing Kubeproxy.
* Enable mDNS on all VMs (all reachable via the .local Domain, including from the macOS Host).
* Simplify and improve the cloud-init scripts.
* Simplify and improve the deployment scripts.
