### PR TITLE
Enhance K8s deployment to enable Cilium Cluster Mesh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
-*kube_config*.conf
+*kubeconfig*.conf
 *.csr
 *.key
 *.crt
-setup_secondary_master.sh
-setup_worker.sh
+setup*.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
-kube_config.conf
+*kube_config*.conf
+*.csr
+*.key
+*.crt
 setup_secondary_master.sh
 setup_worker.sh

--- a/ClusterMesh.md
+++ b/ClusterMesh.md
@@ -1,0 +1,79 @@
+# Cilium ClusterMesh
+
+By default, Cilium will be deployed as CNI with WireGuard encryption enabled. To ensure that all MultiMesh capabilities are available, both clusters must share the same CA. Do the following to create the CA Root Certificate. If exists, the `start.sh` script will pass it to the Masters to ensure Cilium uses it:
+
+```bash=
+step certificate create \
+  root.cilium \
+  ca.crt ca.key \
+  --profile root-ca \
+  --no-password --insecure \
+  --force
+```
+
+> The above assumes you have the [Step CLI](https://smallstep.com/docs/step-cli/) tool installed on your system.
+
+Use the following to deploy two clusters with a single master and two worker nodes:
+
+```bash=
+./start.sh --masters 1 --domain east --id 1 --podCIDR 10.1.0.0/16 --svcCIDR 11.1.0.0/16
+./start.sh --masters 1 --domain west --id 2 --podCIDR 10.2.0.0/16 --svcCIDR 11.2.0.0/16
+```
+
+> Ensure both clusters have different values for `domain`, `id`, `podCIDR`, and `svcCIDR`. As all the nodes from both clusters can reach each other, we have the networking requirements for Cluster Mesh.
+
+Import the `kubeconfig` from both clusters:
+
+```bash=
+./update-config.sh east
+./update-config.sh west
+export KUBECONFIG="$(pwd)/east_kube_config_v2.conf:$(pwd)/west_kube_config_v2.conf"
+```
+
+It is recommended to use `LoadBalancer` as the service type for the mesh connection establishment. For that, we must deploy a Load Balancer solution, so the following installs MetalLB in both clusters:
+
+```bash=
+helm repo add metallb https://metallb.github.io/metallb
+helm repo update
+i=1
+for ctx in "east" "west"; do
+  kubectl config use-context ${ctx}
+  helm install metallb metallb/metallb -n metallb-system --create-namespace --wait
+  cat <<EOF | kubectl apply -f -
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: lb-pool
+  namespace: metallb-system
+spec:
+  addresses:
+  - 192.168.65.2${i}1-192.168.65.2${i}9
+EOF
+  ((i++))
+done
+```
+
+> Ensure the IP ranges are different and won't collide with the IPs assigned to the running Multipass VMs.
+
+Deploy the Cilium ClusterMesh components and connect the clusters:
+
+```bash=
+for ctx in "east" "west"; do
+  cilium clustermesh enable --service-type LoadBalancer --context ${ctx}
+  cilium clustermesh status --wait --context ${ctx}
+done
+cilium clustermesh connect --context east --destination-context west
+```
+
+Run the following command to verify functionality:
+```bash=
+cilium connectivity test --context east --multi-cluster west
+```
+
+Execute the following command to delete the VMs and purge the state of `multipass`:
+
+```bash=
+./cleanup.sh east
+./cleanup.sh west
+rm -f east* west*
+```

--- a/ClusterMesh.md
+++ b/ClusterMesh.md
@@ -38,7 +38,9 @@ helm repo update
 i=1
 for ctx in "east" "west"; do
   kubectl config use-context ${ctx}
-  helm install metallb metallb/metallb -n metallb-system --create-namespace --wait
+  helm install metallb metallb/metallb \
+    --namespace metallb-system --create-namespace \
+    --set speaker.frr.enabled=false --wait
   cat <<EOF | kubectl apply -f -
 apiVersion: metallb.io/v1beta1
 kind: IPAddressPool

--- a/ClusterMesh.md
+++ b/ClusterMesh.md
@@ -4,7 +4,7 @@ By default, Cilium will be deployed as CNI with WireGuard encryption enabled. To
 
 ```bash=
 step certificate create \
-  root.cilium \
+  root.cilium.io \
   ca.crt ca.key \
   --profile root-ca \
   --no-password --insecure \
@@ -16,8 +16,8 @@ step certificate create \
 Use the following to deploy two clusters with a single master and two worker nodes:
 
 ```bash=
-./start.sh --masters 1 --domain east --id 1 --podCIDR 10.1.0.0/16 --svcCIDR 11.1.0.0/16
-./start.sh --masters 1 --domain west --id 2 --podCIDR 10.2.0.0/16 --svcCIDR 11.2.0.0/16
+yes | ./start.sh --masters 1 --domain east --id 1 --podCIDR 10.1.0.0/16 --svcCIDR 11.1.0.0/16
+yes | ./start.sh --masters 1 --domain west --id 2 --podCIDR 10.2.0.0/16 --svcCIDR 11.2.0.0/16
 ```
 
 > Ensure both clusters have different values for `domain`, `id`, `podCIDR`, and `svcCIDR`. As all the nodes from both clusters can reach each other, we have the networking requirements for Cluster Mesh.
@@ -27,44 +27,51 @@ Import the `kubeconfig` from both clusters:
 ```bash=
 ./update-config.sh east
 ./update-config.sh west
-export KUBECONFIG="$(pwd)/east_kube_config_v2.conf:$(pwd)/west_kube_config_v2.conf"
+export KUBECONFIG="$(pwd)/east-kubeconfig.conf:$(pwd)/west-kubeconfig.conf"
 ```
 
-It is recommended to use `LoadBalancer` as the service type for the mesh connection establishment. For that, we must deploy a Load Balancer solution, so the following installs MetalLB in both clusters:
+It is recommended to use `LoadBalancer` as the service type for the mesh connection establishment. For that, we must deploy a Load Balancing solution. We could use MetalLB, but Cilium does offer the same functionality:
 
 ```bash=
-helm repo add metallb https://metallb.github.io/metallb
-helm repo update
-i=1
-for ctx in "east" "west"; do
-  kubectl config use-context ${ctx}
-  helm install metallb metallb/metallb \
-    --namespace metallb-system --create-namespace \
-    --set speaker.frr.enabled=false --wait
-  cat <<EOF | kubectl apply -f -
-apiVersion: metallb.io/v1beta1
-kind: IPAddressPool
+declare -A subnets=([east]=240 [west]=248)
+for domain in east west; do
+  ip=$(multipass list --format json | jq -jr ".list[]|select(.name|test(\"${domain}-master1\"))|.ipv4[0]")
+  cat <<EOF | kubectl create --context ${domain} -f -
+---
+apiVersion: cilium.io/v2alpha1
+kind: CiliumL2AnnouncementPolicy
 metadata:
-  name: lb-pool
-  namespace: metallb-system
+  name: ${domain}-policy
 spec:
-  addresses:
-  - 192.168.65.2${i}1-192.168.65.2${i}9
+  interfaces:
+  - ens3
+  externalIPs: true
+  loadBalancerIPs: true
+---
+apiVersion: cilium.io/v2alpha1
+kind: CiliumLoadBalancerIPPool
+metadata:
+  name: ${domain}-pool
+spec:
+  cidrs:
+  - cidr: "${ip%.*}.${subnets[$domain]}/29"
 EOF
-  ((i++))
 done
 ```
 
-> Ensure the IP ranges are different and won't collide with the IPs assigned to the running Multipass VMs.
+> Ensure the IP ranges are different and won't collide with the IPs assigned to the running Multipass VMs. For reference, the above takes different subnets from the IP of each master node. The primary motivator to use the above solution was that I tried MetalLB, but it didn't work.
 
 Deploy the Cilium ClusterMesh components and connect the clusters:
 
 ```bash=
-for ctx in "east" "west"; do
+for ctx in east west; do
   cilium clustermesh enable --service-type LoadBalancer --context ${ctx}
   cilium clustermesh status --wait --context ${ctx}
 done
 cilium clustermesh connect --context east --destination-context west
+for ctx in east west; do
+  cilium clustermesh status --wait --context ${ctx}
+done
 ```
 
 Run the following command to verify functionality:
@@ -77,5 +84,5 @@ Execute the following command to delete the VMs and purge the state of `multipas
 ```bash=
 ./cleanup.sh east
 ./cleanup.sh west
-rm -f east* west*
+rm -f east-* west-*
 ```

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # Kubernetes Cluster with Multipass
 
-This repository contains a script to set up a simple Kubernetes cluster via [Kubeadm](https://kubernetes.io/docs/reference/setup-tools/kubeadm/) for learning purposes. It deploys Kubernetes version 1.29 using [Cilium](https://cilium.io/) as CNI without Kubeproxy. It will create Ubuntu 22.04 LTS VMs on your machine using [Multipass](https://multipass.run/).
+This repository contains a script to set up a simple Kubernetes cluster via [Kubeadm](https://kubernetes.io/docs/reference/setup-tools/kubeadm/) for learning purposes. It deploys Kubernetes version 1.29 using [Cilium](https://cilium.io/) as CNI without Kubeproxy with encryption enabled. It will create Ubuntu 22.04 LTS VMs on your machine using [Multipass](https://multipass.run/).
 
 This allows you to deploy either a single master or a multi-master deployment.
 
 ## Requirements
 
 Make sure you have [multipass](https://multipass.run/) and [kubectl](https://kubectl.docs.kubernetes.io/) installed on your machine.
+
+Additionally, if you plan to manage [Cilium](https://cilium.io/) from your machine, ensure you have the [CLI installed](https://docs.cilium.io/en/stable/gettingstarted/k8s-install-default/#install-the-cilium-cli); or use it from any of the master nodes.
 
 ## Start the cluster
 
@@ -16,35 +18,22 @@ The following starts a cluster with 3 masters behind a proxy and 3 workers with 
 ./start.sh --workers 3 --cpus 2 --memory 16
 ```
 
-Default values are:
+To learn about all the options and its default values, run the following command:
 
-* 3 master nodes (`--masters`) - use 1 for a single master
-* 2 worker nodes (`--workers`)
-* 2 CPUs per VM (`--cpus`)
-* 8 GB of RAM per VM (`--memory`)
-* 50 GB for Disk per worker VM (`--disk`)
-* All node kinds share the same CPU and Memory.
+```bash=
+./start.sh -h
+```
 
 The cluster is initialized using [cloud-init](https://cloudinit.readthedocs.io/en/latest/), and all the detailes live inside the [kubernetes.yaml](./kubernetes.yaml) file.
 
 ## Interact with the cluster
 
-If you choose to have only one master, open a session against the master:
+Import the `kubeconfig` configuration on your machine:
 
 ```bash=
-multipass shell k8smaster
-```
-
-From there, `kubectl` is already configured for the default user (i.e., `ubuntu`), and the alias `k` can be used. In both cases, bash-completion is enabled.
-
-However, if you choose to have multiple master servers, an additional load balancer was configured, and you can do the following from hour machine (assuming you have `kubectl` installed):
-
-```bash=
-export KUBECONFIG=$(pwd)/kube_config.conf
+export KUBECONFIG=$(pwd)/k8s_kube_config.conf
 kubectl get nodes
 ```
-
-> The `kube_config.conf` file was created by the `start.sh` script and should use the LB to access the cluster.
 
 ## Clean up
 

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -4,7 +4,9 @@ set -euo pipefail
 trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 type multipass >/dev/null 2>&1 || { echo >&2 "multipass required but it's not installed; aborting."; exit 1; }
 
-instances=$(multipass list | grep "^k8s" | awk '{print $1}' | tr '\n' ' ')
-multipass delete --purge $instances
+domain="${1-k8s}"
+
+instances=$(multipass list | grep "^${domain}" | awk '{print $1}' | tr '\n' ' ')
+multipass delete --purge ${instances}
 
 echo "Done!"

--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -169,9 +169,8 @@ packages:
 
 runcmd:
 - systemctl restart systemd-sysctl
-- systemctl restart systemd-resolved.service
-- systemctl start mdns@ens3.service
-- systemctl enable mdns@ens3.service
+- systemctl restart systemd-resolved
+- systemctl --now enable mdns@ens3
 - timedatectl set-timezone America/New_York
 - timedatectl set-ntp on
 - systemctl stop apparmor

--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -70,29 +70,63 @@ write_files:
   content: |
     #!/bin/bash
     set -e
-    snap install helm --classic
-    helm repo add cilium https://helm.cilium.io/
-    helm repo update
+    id=${1-1}
+    version=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/main/stable.txt)
+    curl -L --fail --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${version}/cilium-linux-amd64.tar.gz
+    tar xzvfC cilium-linux-amd64.tar.gz /usr/local/bin
     export KUBECONFIG=/etc/kubernetes/admin.conf
-    ipaddr=$(ifconfig | grep 'inet[^6]' | awk '{print $2}' | grep -v '127.0.0.1')
-    helm install cilium cilium/cilium -n kube-system \
-      --set kubeProxyReplacement=true \
-      --set k8sServiceHost=${ipaddr} \
-      --set k8sServicePort=6443 \
-      --set operator.replicas=1 \
+    if [ -e /tmp/ca.crt ] && [ -e /tmp/ca.key ]; then
+      kubectl create secret generic cilium-ca -n kube-system --from-file=/tmp/ca.crt --from-file=/tmp/ca.key
+      kubectl label secret -n kube-system cilium-ca app.kubernetes.io/managed-by=Helm
+      kubectl annotate secret -n kube-system cilium-ca meta.helm.sh/release-name=cilium
+      kubectl annotate secret -n kube-system cilium-ca meta.helm.sh/release-namespace=kube-system
+    fi
+    cilium install --wait \
+      --set cluster.id=${id} \
+      --set ipam.mode=kubernetes \
+      --set encryption.enabled=true \
+      --set encryption.type=wireguard \
       --set hubble.relay.enabled=true \
-      --set hubble.ui.enabled=true \
-      --wait
+      --set hubble.ui.enabled=true
+
+- path: /usr/local/bin/kubernetes-create-config.sh
+  permissions: '0755'
+  content: |
+    #!/bin/bash
+    set -e
+    ipaddr=$(ifconfig | grep 'inet[^6]' | awk '{print $2}' | grep -v '127.0.0.1')
+    hostname=$(hostname)
+    clusterName=${hostname%-*}
+    podSubnet=${1-10.244.0.0/16}
+    serviceSubnet=${2-10.96.0.0/12}
+    ctrlEndpoint=${3-$ipaddr}
+    cat <<EOF > /etc/kubernetes/kubeadm-config.yaml
+    ---
+    apiVersion: kubeadm.k8s.io/v1beta3
+    kind: InitConfiguration
+    localAPIEndpoint:
+      advertiseAddress: "${ipaddr}"
+    skipPhases:
+    - addon/kube-proxy
+    ---
+    apiVersion: kubeadm.k8s.io/v1beta3
+    kind: ClusterConfiguration
+    clusterName: "${clusterName}"
+    controlPlaneEndpoint: "${ctrlEndpoint}"
+    networking:
+      podSubnet: "${podSubnet}"
+      serviceSubnet: "${serviceSubnet}"
+    EOF
 
 - path: /usr/local/bin/kubernetes-setup-single-master.sh
   permissions: '0755'
   content: |
     #!/bin/bash
     set -e
-    ipaddr=$(ifconfig | grep 'inet[^6]' | awk '{print $2}' | grep -v '127.0.0.1')
-    kubeadm init --apiserver-advertise-address=${ipaddr} --pod-network-cidr=10.244.0.0/16 --skip-phases=addon/kube-proxy
+    id=${1-1}
+    kubeadm init --config=/etc/kubernetes/kubeadm-config.yaml
     kubeadm token create --print-join-command > /tmp/setup_worker.sh
-    /usr/local/bin/kubernetes-setup-cni.sh
+    /usr/local/bin/kubernetes-setup-cni.sh ${id}
     /usr/local/bin/kubernetes-setup-kubectl.sh
 
 - path: /usr/local/bin/kubernetes-setup-primary-master.sh
@@ -100,14 +134,12 @@ write_files:
   content: |
     #!/bin/bash
     set -e
-    proxy_fqdn=${1-k8smain.local}
-    ipaddr=$(ifconfig | grep 'inet[^6]' | awk '{print $2}' | grep -v '127.0.0.1')
-    kubeadm init --apiserver-advertise-address=${ipaddr} --pod-network-cidr=10.244.0.0/16 --skip-phases=addon/kube-proxy \
-      --control-plane-endpoint=${proxy_fqdn}:6443 --upload-certs
+    id=${1-1}
+    kubeadm init --config=/etc/kubernetes/kubeadm-config.yaml --upload-certs
     cert_key=$(sudo kubeadm init phase upload-certs --upload-certs | tail -n 1)
     kubeadm token create --print-join-command --certificate-key $cert_key > /tmp/setup_secondary_master.sh
     kubeadm token create --print-join-command > /tmp/setup_worker.sh
-    /usr/local/bin/kubernetes-setup-cni.sh
+    /usr/local/bin/kubernetes-setup-cni.sh ${id}
     /usr/local/bin/kubernetes-setup-kubectl.sh
 
 - path: /usr/local/bin/kubernetes-setup-secondary-master.sh

--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -99,7 +99,11 @@ write_files:
     clusterName=${hostname%-*}
     podSubnet=${1-10.244.0.0/16}
     serviceSubnet=${2-10.96.0.0/12}
-    ctrlEndpoint=${3-$ipaddr}
+    if [ "${3}" == "" ]; then
+      ctrlEndpoint=$ipaddr
+    else
+      ctrlEndpoint=$(dig ${3} +short)
+    fi
     cat <<EOF > /etc/kubernetes/kubeadm-config.yaml
     ---
     apiVersion: kubeadm.k8s.io/v1beta3

--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -86,6 +86,9 @@ write_files:
       --set ipam.mode=kubernetes \
       --set encryption.enabled=true \
       --set encryption.type=wireguard \
+      --set devices=ens+ \
+      --set l2announcements.enabled=true \
+      --set externalIPs.enabled=true \
       --set hubble.relay.enabled=true \
       --set hubble.ui.enabled=true
 
@@ -120,6 +123,10 @@ write_files:
     networking:
       podSubnet: "${podSubnet}"
       serviceSubnet: "${serviceSubnet}"
+    ---
+    kind: KubeletConfiguration
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    cgroupDriver: systemd
     EOF
 
 - path: /usr/local/bin/kubernetes-setup-single-master.sh
@@ -171,6 +178,7 @@ runcmd:
 - systemctl restart systemd-sysctl
 - systemctl restart systemd-resolved
 - systemctl --now enable mdns@ens3
+- ufw disable
 - timedatectl set-timezone America/New_York
 - timedatectl set-ntp on
 - systemctl stop apparmor
@@ -182,4 +190,5 @@ runcmd:
 - mkdir -p /etc/containerd
 - containerd config default | sed '/SystemdCgroup/s/false/true/' > /etc/containerd/config.toml
 - systemctl restart containerd
+- systemctl enable containerd
 - kubernetes-install.sh

--- a/load-balancer.yaml
+++ b/load-balancer.yaml
@@ -33,7 +33,7 @@ write_files:
       exit
     fi
     masters=${1-3}
-    master_prefix=${2-k8smaster}
+    master_prefix=${2-k8s-master}
     cp /etc/haproxy/haproxy.cfg /etc/haproxy/haproxy.cfg.bak
     cat <<EOF | sudo tee -a /etc/haproxy/haproxy.cfg
     frontend kube-apiserver

--- a/start.sh
+++ b/start.sh
@@ -56,7 +56,7 @@ fi
 proxy_hostname="${domain}-main"
 master_prefix="${domain}-master"
 worker_prefix="${domain}-worker"
-kube_config="${domain}_kube_config.conf"
+kubeconfig="${domain}-kubeconfig.conf"
 
 # Infrastructure Verification
 nodes=$(($masters + $workers))
@@ -122,7 +122,7 @@ else
 fi
 
 # Copy configuration
-multipass transfer ${master_prefix}1:/home/ubuntu/.kube/config ${kube_config}
+multipass transfer ${master_prefix}1:/home/ubuntu/.kube/config ${kubeconfig}
 
 # Configure Worker nodes
 for i in $(seq 1 ${workers}); do
@@ -135,5 +135,5 @@ done
 # Finalizing
 rm -f ./setup_secondary_master.sh ./setup_worker.sh
 echo "To access the cluster locally use:"
-echo "export KUBECONFIG=$(pwd)/${kube_config}"
+echo "export KUBECONFIG=$(pwd)/${kubeconfig}"
 echo "Done!"

--- a/start.sh
+++ b/start.sh
@@ -78,7 +78,7 @@ echo
 if [[ ! $REPLY =~ ^[Yy]$ ]]; then
   exit
 fi
-echo "Creating Kubernetes cluster..."
+echo "Creating Kubernetes cluster ${domain}..."
 
 # Start VMs for the Master nodes
 for i in $(seq 1 ${masters}); do

--- a/update-config.sh
+++ b/update-config.sh
@@ -1,6 +1,6 @@
 #!/usr/local/bin/bash
 
-set -e
+set -eu
 
 for cmd in "multipass" "openssl" "kubectl"; do
   type $cmd >/dev/null 2>&1 || { echo >&2 "$cmd required but it's not installed; aborting."; exit 1; }
@@ -8,7 +8,7 @@ done
 
 domain=${1-east}
 user="${domain}-admin"
-fileName="${domain}_kube_config.conf"
+fileName="${domain}-kubeconfig.conf"
 
 multipass transfer ${domain}-master1:/home/ubuntu/.kube/config ${fileName}
 
@@ -39,4 +39,7 @@ kubectl get csr ${user} -o jsonpath='{.status.certificate}' | base64 -d > ${user
 kubectl config set-credentials ${user} --client-certificate=${user}.crt --client-key=${user}.key --embed-certs=true
 kubectl config set-context ${domain} --user=${user} --cluster=${domain}
 kubectl config use-context ${domain}
-kubectl config view --kubeconfig=${fileName} --minify --flatten > ${domain}_kube_config_v2.conf
+kubectl config view --kubeconfig=${fileName} --minify --flatten > ${fileName}.tmp
+
+mv -f ${fileName}.tmp ${fileName}
+rm -f ${user}.*

--- a/update-config.sh
+++ b/update-config.sh
@@ -1,0 +1,42 @@
+#!/usr/local/bin/bash
+
+set -e
+
+for cmd in "multipass" "openssl" "kubectl"; do
+  type $cmd >/dev/null 2>&1 || { echo >&2 "$cmd required but it's not installed; aborting."; exit 1; }
+done
+
+domain=${1-east}
+user="${domain}-admin"
+fileName="${domain}_kube_config.conf"
+
+multipass transfer ${domain}-master1:/home/ubuntu/.kube/config ${fileName}
+
+export KUBECONFIG="${fileName}"
+kubectl config use-context kubernetes-admin@${domain}
+
+openssl genrsa -out ${user}.key 2048
+openssl req -new -key ${user}.key -out ${user}.csr -subj "/CN=${user}/O=kubeadm:cluster-admins"
+
+cat <<EOF | kubectl apply -f -
+apiVersion: certificates.k8s.io/v1
+kind: CertificateSigningRequest
+metadata:
+  name: ${user}
+spec:
+  request: $(cat ${user}.csr | base64 | tr -d '\n')
+  signerName: kubernetes.io/kube-apiserver-client
+  groups:
+  - kubeadm:cluster-admins
+  usages:
+  - digital signature
+  - key encipherment
+  - client auth
+EOF
+
+kubectl certificate approve ${user}
+kubectl get csr ${user} -o jsonpath='{.status.certificate}' | base64 -d > ${user}.crt
+kubectl config set-credentials ${user} --client-certificate=${user}.crt --client-key=${user}.key --embed-certs=true
+kubectl config set-context ${domain} --user=${user} --cluster=${domain}
+kubectl config use-context ${domain}
+kubectl config view --kubeconfig=${fileName} --minify --flatten > ${domain}_kube_config_v2.conf


### PR DESCRIPTION
* The `cloud-init` definition was enhanced to provide a centralized configuration for `kubeadm` with custom CIDR/Subnets for Pods and Services.
* Deploy Cilium via CLI instead of Helm, as it provides better defaults and a more effortless user experience.
* Enabled Encryption using WireGuard.
* Added a flag called `domain` to allow the creation of multiple Kubernetes clusters on the same physical machine.
* Added `ClusterMesh.md` to explain deploying two clusters and enabling Cluster Mesh between them using a shared CA.
* Simplified `README.md` to be more concise and easy to follow.
* Created `update-config.sh` to create a custom admin user on each cluster to combine multiple `kubeconfig` files to manage the generated clusters.