### PR TITLE
Remove mDNS usage (not needed).

### DIFF
--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -3,20 +3,6 @@ package_upgrade: true
 
 write_files:
 
-- path: /etc/systemd/resolved.conf
-  append: true
-  content: |
-    MulticastDNS=yes
-
-- path: /etc/systemd/system/mdns@.service
-  content: |
-    [Service]
-    Type=oneshot
-    ExecStart=/usr/bin/resolvectl mdns %i yes
-    After=sys-subsystem-net-devices-%i.device
-    [Install]
-    WantedBy=sys-subsystem-net-devices-%i.device
-
 - path: /etc/modules-load.d/containerd.conf
   content: |
     overlay
@@ -38,7 +24,7 @@ write_files:
   permissions: '0755'
   content: |
     #!/bin/bash
-    set -e
+    set -eu
     DEBIAN_FRONTEND=noninteractive
     VERSION=v1.29
     curl -fsSL https://pkgs.k8s.io/core:/stable:/${VERSION}/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
@@ -51,7 +37,7 @@ write_files:
   permissions: '0755'
   content: |
     #!/bin/bash
-    set -e
+    set -eu
     kubectl completion bash > /etc/bash_completion.d/kubectl
     user=ubuntu
     home=/home/$user
@@ -69,7 +55,7 @@ write_files:
   permissions: '0755'
   content: |
     #!/bin/bash
-    set -e
+    set -eu
     id=${1-1}
     version=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/main/stable.txt)
     curl -L --fail --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${version}/cilium-linux-amd64.tar.gz
@@ -96,17 +82,13 @@ write_files:
   permissions: '0755'
   content: |
     #!/bin/bash
-    set -e
+    set -eu
     ipaddr=$(ifconfig | grep 'inet[^6]' | awk '{print $2}' | grep -v '127.0.0.1')
     hostname=$(hostname)
     clusterName=${hostname%-*}
     podSubnet=${1-10.244.0.0/16}
     serviceSubnet=${2-10.96.0.0/12}
-    if [ "${3}" == "" ]; then
-      ctrlEndpoint=$ipaddr
-    else
-      ctrlEndpoint=$(dig ${3} +short)
-    fi
+    ctrlEndpoint=${3-${ipaddr}}
     cat <<EOF > /etc/kubernetes/kubeadm-config.yaml
     ---
     apiVersion: kubeadm.k8s.io/v1beta3
@@ -133,7 +115,7 @@ write_files:
   permissions: '0755'
   content: |
     #!/bin/bash
-    set -e
+    set -eu
     id=${1-1}
     kubeadm init --config=/etc/kubernetes/kubeadm-config.yaml
     kubeadm token create --print-join-command > /tmp/setup_worker.sh
@@ -144,7 +126,7 @@ write_files:
   permissions: '0755'
   content: |
     #!/bin/bash
-    set -e
+    set -eu
     id=${1-1}
     kubeadm init --config=/etc/kubernetes/kubeadm-config.yaml --upload-certs
     cert_key=$(sudo kubeadm init phase upload-certs --upload-certs | tail -n 1)
@@ -157,7 +139,7 @@ write_files:
   permissions: '0755'
   content: |
     #!/bin/bash
-    set -e
+    set -eu
     if ! [ -f "/tmp/setup_secondary_master.sh" ]; then
       echo "Cannot find join script..."
       exit
@@ -176,8 +158,6 @@ packages:
 
 runcmd:
 - systemctl restart systemd-sysctl
-- systemctl restart systemd-resolved
-- systemctl --now enable mdns@ens3
 - ufw disable
 - timedatectl set-timezone America/New_York
 - timedatectl set-ntp on

--- a/load-balancer.yaml
+++ b/load-balancer.yaml
@@ -38,8 +38,8 @@ write_files:
       master="${master_prefix}${i}"
       cat <<EOF | sudo tee -a /etc/haproxy/haproxy.cfg
         server ${master} ${ip}:6443 check
-      ((i++))
     EOF
+      ((i++))
     done
     touch /etc/haproxy.configured
     sudo systemctl restart haproxy

--- a/load-balancer.yaml
+++ b/load-balancer.yaml
@@ -27,13 +27,13 @@ write_files:
   permissions: '0755'
   content: |
     #!/bin/bash
-    set -e
+    set -eu
     if [ -f "/etc/haproxy.configured" ]; then
       echo "Already configured."
       exit
     fi
-    masters=${1-3}
-    master_prefix=${2-k8s-master}
+    master_prefix=${1-k8s-master}
+    addresses=${2} # space separated list of IP addresses
     cp /etc/haproxy/haproxy.cfg /etc/haproxy/haproxy.cfg.bak
     cat <<EOF | sudo tee -a /etc/haproxy/haproxy.cfg
     frontend kube-apiserver
@@ -47,11 +47,12 @@ write_files:
         balance roundrobin
         default-server inter 10s downinter 5s rise 2 fall 2 slowstart 60s maxconn 250 maxqueue 256 weight 100
     EOF
-    for i in $(seq 1 ${masters}); do
+    i=1
+    for ip in ${addresses}; do
       master="${master_prefix}${i}"
-      ip=$(dig ${master}.local +short)
       cat <<EOF | sudo tee -a /etc/haproxy/haproxy.cfg
         server ${master} ${ip}:6443 check
+      ((i++))
     EOF
     done
     touch /etc/haproxy.configured

--- a/load-balancer.yaml
+++ b/load-balancer.yaml
@@ -3,20 +3,6 @@ package_upgrade: true
 
 write_files:
 
-- path: /etc/systemd/resolved.conf
-  append: true
-  content: |
-    MulticastDNS=yes
-
-- path: /etc/systemd/system/mdns@.service
-  content: |
-    [Service]
-    Type=oneshot
-    ExecStart=/usr/bin/resolvectl mdns %i yes
-    After=sys-subsystem-net-devices-%i.device
-    [Install]
-    WantedBy=sys-subsystem-net-devices-%i.device
-
 - path: /etc/sysctl.d/no-ipv6.conf
   content: |
     net.ipv6.conf.all.disable_ipv6     = 1
@@ -64,9 +50,6 @@ packages:
 
 runcmd:
 - systemctl restart systemd-sysctl
-- systemctl restart systemd-resolved.service
-- systemctl start mdns@ens3.service
-- systemctl enable mdns@ens3.service
 - timedatectl set-timezone America/New_York
 - timedatectl set-ntp on
 - systemctl stop apparmor

--- a/start.sh
+++ b/start.sh
@@ -102,9 +102,11 @@ master="${master_prefix}1"
 if [[ ${masters} > 1 ]]; then
   echo "Configuring Load Balancer..."
   multipass launch -c 1 -m 1g -n ${proxy_hostname} --cloud-init load-balancer.yaml
-  multipass exec ${proxy_hostname} -- sudo /etc/haproxy/setup.sh ${masters} ${master_prefix}
+  proxy_ip=$(multipass list --format json | jq -r ".list[]|select(.name|test(\"${proxy_hostname}\"))|.ipv4[0]")
+  addresses=$(multipass list --format json | jq -r "[.list[]|select(.name|test(\"master\"))|.ipv4[0]]|join(\" \")")
+  multipass exec ${proxy_hostname} -- sudo /etc/haproxy/setup.sh "${master_prefix}" "${addresses}"
   echo "Initializing primary master node ${master}..."
-  multipass exec ${master} -- sudo kubernetes-create-config.sh ${podCIDR} ${svcCIDR} ${proxy_hostname}.local
+  multipass exec ${master} -- sudo kubernetes-create-config.sh ${podCIDR} ${svcCIDR} ${proxy_ip}
   multipass exec ${master} -- sudo kubernetes-setup-primary-master.sh ${id}
   multipass transfer ${master}:/tmp/setup_secondary_master.sh .
   multipass transfer ${master}:/tmp/setup_worker.sh .

--- a/start.sh
+++ b/start.sh
@@ -102,8 +102,8 @@ master="${master_prefix}1"
 if [[ ${masters} > 1 ]]; then
   echo "Configuring Load Balancer..."
   multipass launch -c 1 -m 1g -n ${proxy_hostname} --cloud-init load-balancer.yaml
-  proxy_ip=$(multipass list --format json | jq -r ".list[]|select(.name|test(\"${proxy_hostname}\"))|.ipv4[0]")
-  addresses=$(multipass list --format json | jq -r "[.list[]|select(.name|test(\"master\"))|.ipv4[0]]|join(\" \")")
+  proxy_ip=$(multipass info ${proxy_hostname} | grep IPv4 | awk '{print $2}')
+  addresses=$(multipass info ${master_prefix}{1..${masters}} | grep IPv4 | awk '{print $2}' | tr '\n' ' ')
   multipass exec ${proxy_hostname} -- sudo /etc/haproxy/setup.sh "${master_prefix}" "${addresses}"
   echo "Initializing primary master node ${master}..."
   multipass exec ${master} -- sudo kubernetes-create-config.sh ${podCIDR} ${svcCIDR} ${proxy_ip}


### PR DESCRIPTION
Initially, I thought about having mDNS use FQDNs when interacting with the cluster members, but then I figured out that's unnecessary. Also, `kubeadm` and `HAProxy` need to know the IP addresses, so I removed mDNS.